### PR TITLE
fix: declare the autostart desktop file so launch at login works

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,10 @@ parts:
 apps:
   localsend:
     command: opt/localsend_app/localsend_app
+    # Name of the desktop file the app writes into $SNAP_USER_DATA/.config/autostart
+    # when "Autostart after login" is enabled. snapd only launches an autostart
+    # desktop file that is declared here.
+    autostart: localsend_app.desktop
     extensions: [gnome]
     plugs:
       - home


### PR DESCRIPTION
### Problem

"Autostart after login" and "Autostart: start hidden" have no effect on the
snap. The app has to be started by hand on every login.

### Cause

The app writes `localsend_app.desktop` into `$SNAP_USER_DATA/.config/autostart`,
which is the right place for a confined snap. snapd picks it up through
`/etc/xdg/autostart/snap-userd-autostart.desktop` but refuses to launch it:

```
$ snap userd --autostart
error: autostart failed:
- "localsend_app.desktop": cannot match desktop file with snap localsend applications
```

snapd only starts an autostart desktop file that the app declares through the
`autostart` key, see `usersession/autostart/autostart.go`:

```go
for _, candidate := range info.Apps {
    if candidate.Autostart == desktopFile { app = candidate; break }
}
if app == nil {
    return nil, fmt.Errorf("cannot match desktop file with snap %s applications", snapName)
}
```

### Fix

Declare the file name the app writes. `--hidden` keeps working, because snapd
replaces only `argv[0]` with the app wrapper and preserves the rest:

```go
// NOTE: Ignore the actual argv[0] in Exec=.. line and replace it with a
// command of the snap application. Any arguments passed in the Exec=..
// line to the original command are preserved.
cmd := exec.Command(app.WrapperPath(), args[1:]...)
```

### Testing

`snapcraft expand-extensions` accepts the key and it survives extension
expansion. Reproduced on Ubuntu 26.04 with snapd 2.76.3 and revision 35.
