### PR TITLE
fix: set StartupWMClass so the window matches the desktop entry

### DIFF
--- a/snap/gui/localsend.desktop
+++ b/snap/gui/localsend.desktop
@@ -6,3 +6,4 @@ Icon=${SNAP}/meta/gui/localsend.png
 Terminal=false
 Type=Application
 Categories=Utility;
+StartupWMClass=org.localsend.localsend_app


### PR DESCRIPTION
### Problem

The dock and alt-tab show a generic icon for the running window instead of the
LocalSend logo.

### Cause

The app sets its GTK application id to `org.localsend.localsend_app`:

```cmake
set(APPLICATION_ID "org.localsend.localsend_app")   # linux/CMakeLists.txt
```
```cpp
g_set_prgname(APPLICATION_ID);                      # linux/my_application.cc
```

The exported entry is `localsend_localsend.desktop` and declares no
`StartupWMClass`, so nothing maps the window back to it. GNOME Shell tries, in
order, `StartupWMClass` against the WM_CLASS instance and class, then a desktop
file named after them, and finally the GApplication id, see
`get_app_from_window_wmclass` in `shell-window-tracker.c`. Every step looks for
`org.localsend.localsend_app`, which matches nothing.

The snap connects to the session compositor socket directly rather than through
a Wayland security context, so `meta_window_get_sandboxed_app_id` returns NULL
and the snap-aware matching paths never kick in either.

### Testing

Observed on Ubuntu 26.04, GNOME on Wayland, revision 35.
